### PR TITLE
Fix dynamic shortcuts in release version

### DIFF
--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -12,7 +12,7 @@
         android:shortcutLongLabel="@string/home_screen_shortcut_open_new_tab_2">
         <intent
             android:action="net.waterfox.android.OPEN_TAB"
-            android:targetPackage="net.waterfox.android"
+            android:targetPackage="net.waterfox.android.release"
             android:targetClass="net.waterfox.android.IntentReceiverActivity" />
     </shortcut>
     <shortcut
@@ -23,7 +23,7 @@
         android:shortcutLongLabel="@string/home_screen_shortcut_open_new_private_tab_2">
         <intent
             android:action="net.waterfox.android.OPEN_PRIVATE_TAB"
-            android:targetPackage="net.waterfox.android"
+            android:targetPackage="net.waterfox.android.release"
             android:targetClass="net.waterfox.android.IntentReceiverActivity" />
     </shortcut>
 </shortcuts>


### PR DESCRIPTION
Add application suffix to target packages in shortcuts.xml.

Waterfox for Android (which I install from Play Store) comes with `net.waterfox.android.release` package name (version 1.0.9.2).
So in order to start intent targetPackage should also contain ".release".

Closes #90 